### PR TITLE
Handling terminal resize signal

### DIFF
--- a/include/graphics/menu.h
+++ b/include/graphics/menu.h
@@ -15,6 +15,7 @@ struct Menu_
 };
 typedef struct Menu_ Menu;
 
+void sig_winch(int signo);
 void check_terminal_size();
 
 void ncurses_init();

--- a/src/graphics/menu.c
+++ b/src/graphics/menu.c
@@ -1,7 +1,13 @@
 #include <termios.h>
 #include <stdlib.h>
+#include <signal.h>
 #include <sys/ioctl.h>
 #include "../../include/graphics/menu.h"
+
+void sig_winch(int signo)
+{
+	
+}
 
 void check_terminal_size()
 {
@@ -20,6 +26,7 @@ void ncurses_init()
 	check_terminal_size();
 	
 	initscr();
+	signal(SIGWINCH, sig_winch);
 	cbreak();
 	curs_set(0);
 	start_color();


### PR DESCRIPTION
Мнимо обрабатываю сигнал sig_winch, чтобы предовратить затирание меню. Решение не идеальное, так как если очень постараться можно всё-таки добиться визуальных нечёткостей (Например, сжать терминал по высоте на несколько строк, а потом расширить. При этом часть фона приложения сотрётся)
P.S. Конечно, можно вручную пройтись по всем вложенным окнам и обновить их самостоятельно, но для этого мне нужно каким-то образом в обработчике сигнала добраться до структуры меню. Единственный способ это сделать - объявить экземпляр структуры глобально, чего я не очень хочу делать
P.S.S Я бы  вообще запретил изменение размера терминала, просто вызывая крах программы при данном событии